### PR TITLE
Updates the clockie delay structure

### DIFF
--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_applications.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_applications.dm
@@ -23,7 +23,7 @@
 	quickbind = TRUE
 	quickbind_desc = "Creates a Sigil of Transmission, which can drain and will store power for clockwork structures."
 
-/*//Prolonging Prism: Creates a prism that will delay the shuttle at a power cost
+//Prolonging Prism: Creates a prism that will delay the shuttle at a power cost
 /datum/clockwork_scripture/create_object/prolonging_prism
 	descname = "Powered Structure, Delay Emergency Shuttles"
 	name = "Prolonging Prism"
@@ -40,7 +40,7 @@
 	tier = SCRIPTURE_APPLICATION
 	one_per_tile = TRUE
 	primary_component = VANGUARD_COGWHEEL
-	sort_priority = 7
+	sort_priority = 4
 	important = TRUE
 	quickbind = TRUE
 	quickbind_desc = "Creates a Prolonging Prism, which will delay the arrival of an emergency shuttle by 2 minutes at a massive power cost."
@@ -50,11 +50,10 @@
 		to_chat(invoker, "<span class='inathneq'>\"It is too late to construct one of these, champion.\"</span>")
 		return FALSE
 	var/turf/T = get_turf(invoker)
-	if(!T || !(T.z in GLOB.station_z_levels))
+	if(!T || !is_station_level(T.z))
 		to_chat(invoker, "<span class='inathneq'>\"You must be on the station to construct one of these, champion.\"</span>")
 		return FALSE
 	return ..()
-*/
 
 //Mania Motor: Creates a malevolent transmitter that will broadcast the whispers of Sevtug into the minds of nearby nonservants, causing a variety of mental effects at a power cost.
 /datum/clockwork_scripture/create_object/mania_motor
@@ -112,7 +111,7 @@
 	usage_tip = "guardians are useful as personal bodyguards and frontline warriors."
 	tier = SCRIPTURE_APPLICATION
 	primary_component = GEIS_CAPACITOR
-	sort_priority = 3
+	sort_priority = 5
 
 /datum/clockwork_scripture/memory_allocation/check_special_requirements()
 	for(var/mob/living/simple_animal/hostile/clockwork/marauder/guardian/M in GLOB.all_clockwork_mobs)
@@ -171,7 +170,7 @@
 	tier = SCRIPTURE_APPLICATION
 	one_per_tile = TRUE
 	primary_component = BELLIGERENT_EYE
-	sort_priority = 4
+	sort_priority = 6
 	quickbind = TRUE
 	quickbind_desc = "Creates a clockwork marauder, used for frontline combat."
 	object_path = /obj/item/clockwork/construct_chassis/clockwork_marauder
@@ -223,7 +222,7 @@
 	object_path = /obj/mecha/combat/neovgre
 	tier = SCRIPTURE_APPLICATION
 	primary_component = BELLIGERENT_EYE
-	sort_priority = 5
+	sort_priority = 7
 	creator_message = "<span class='brass'>Neovgre, the Anima Bulwark towers over you... your enemies reckoning has come.</span>"
 
 /datum/clockwork_scripture/create_object/summon_arbiter/check_special_requirements()

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_judgement.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_judgement.dm
@@ -20,7 +20,7 @@
 	usage_tip = "The gateway is completely vulnerable to attack during its five-minute duration. It will periodically give indication of its general position to everyone on the station \
 	as well as being loud enough to be heard throughout the entire sector. Defend it with your life!"
 	tier = SCRIPTURE_APPLICATION
-	sort_priority = 6
+	sort_priority = 8
 
 /datum/clockwork_scripture/create_object/ark_of_the_clockwork_justiciar/check_special_requirements()
 	if(!slab.no_cost)

--- a/code/modules/antagonists/clockcult/clock_structures/prolonging_prism.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/prolonging_prism.dm
@@ -1,6 +1,3 @@
-//this needs heavily updated, but the mode should work without it if its testmerged, the ark stops the shuttle from launching anyway so as long as they summon it things should be fine
-
-
 //Prolonging Prism: A prism that consumes power to delay the shuttle
 /obj/structure/destructible/clockwork/powered/prolonging_prism
 	name = "prolonging prism"
@@ -18,19 +15,19 @@
 	/obj/item/clockwork/alloy_shards/large = 1, \
 	/obj/item/clockwork/component/vanguard_cogwheel/onyx_prism = 1)
 	var/static/power_refund = 250
-	var/static/delay_cost = 3000
-	var/static/delay_cost_increase = 1250
+	var/static/delay_cost = 2000 //Updated power values for new-newclock. Easier to activate and sustain, you are quite literally pointing the entire station towards you as opposed to blood-delay after all.
+	var/static/delay_cost_increase = 1000
 	var/static/delay_remaining = 0
 
 /obj/structure/destructible/clockwork/powered/prolonging_prism/examine(mob/user)
-	..()
+	. = ..()
 	if(is_servant_of_ratvar(user) || isobserver(user))
 		if(SSshuttle.emergency.mode == SHUTTLE_DOCKED || SSshuttle.emergency.mode == SHUTTLE_IGNITING || SSshuttle.emergency.mode == SHUTTLE_STRANDED || SSshuttle.emergency.mode == SHUTTLE_ESCAPE)
-			to_chat(user, "<span class='inathneq'>An emergency shuttle has arrived and this prism is no longer useful; attempt to activate it to gain a partial refund of components used.</span>")
+			. += "<span class='inathneq'>An emergency shuttle has arrived and this prism is no longer useful; attempt to activate it to gain a partial refund of components used.</span>"
 		else
 			var/efficiency = get_efficiency_mod(TRUE)
-			to_chat(user, "<span class='inathneq_small'>It requires at least <b>[DisplayPower(get_delay_cost())]</b> of power to attempt to delay the arrival of an emergency shuttle by <b>[2 * efficiency]</b> minutes.</span>")
-			to_chat(user, "<span class='inathneq_small'>This cost increases by <b>[DisplayPower(delay_cost_increase)]</b> for every previous activation.</span>")
+			. += "<span class='inathneq_small'>It requires at least <b>[DisplayPower(get_delay_cost())]</b> of power to attempt to delay the arrival of an emergency shuttle by <b>[2 * efficiency]</b> minutes.</span>"
+			. += "<span class='inathneq_small'>This cost increases by <b>[DisplayPower(delay_cost_increase)]</b> for every previous activation.</span>"
 
 /obj/structure/destructible/clockwork/powered/prolonging_prism/forced_disable(bad_effects)
 	if(active)
@@ -43,15 +40,14 @@
 /obj/structure/destructible/clockwork/powered/prolonging_prism/attack_hand(mob/living/user)
 	if(user.canUseTopic(src, !issilicon(user), NO_DEXTERY) && is_servant_of_ratvar(user))
 		if(SSshuttle.emergency.mode == SHUTTLE_DOCKED || SSshuttle.emergency.mode == SHUTTLE_IGNITING || SSshuttle.emergency.mode == SHUTTLE_STRANDED || SSshuttle.emergency.mode == SHUTTLE_ESCAPE)
-			to_chat(user, "<span class='brass'>You break [src] apart, refunding some of the components used.</span>")
-			for(var/i in power_refund)
-				generate_cache_component(i, src)
+			to_chat(user, "<span class='brass'>You break [src] apart, refunding some of the power used.</span>")
+			adjust_clockwork_power(power_refund)
 			take_damage(max_integrity)
 			return 0
 		if(active)
 			return 0
 		var/turf/T = get_turf(src)
-		if(!T || !(T.z in GLOB.station_z_levels))
+		if(!T || !is_station_level(T.z))
 			to_chat(user, "<span class='warning'>[src] must be on the station to function!</span>")
 			return 0
 		if(SSshuttle.emergency.mode != SHUTTLE_CALL)
@@ -66,7 +62,7 @@
 
 /obj/structure/destructible/clockwork/powered/prolonging_prism/process()
 	var/turf/own_turf = get_turf(src)
-	if(SSshuttle.emergency.mode != SHUTTLE_CALL || delay_remaining <= 0 || !own_turf || !(own_turf.z in GLOB.station_z_levels))
+	if(SSshuttle.emergency.mode != SHUTTLE_CALL || delay_remaining <= 0 || !own_turf || !is_station_level(own_turf.z))
 		forced_disable(FALSE)
 		return
 	. = ..()
@@ -90,36 +86,36 @@
 			lowest_y = T.y
 		if(!lowest_x || T.x < lowest_x)
 			lowest_x = T.x
-	var/mean_y = Lerp(lowest_y, highest_y)
-	var/mean_x = Lerp(lowest_x, highest_x)
+	var/mean_y = LERP(lowest_y, highest_y, 0.5)
+	var/mean_x = LERP(lowest_x, highest_x, 0.5)
 	if(prob(50))
-		mean_y = Ceiling(mean_y)
+		mean_y = CEILING(mean_y, 1)
 	else
-		mean_y = Floor(mean_y)
+		mean_y = FLOOR(mean_y, 1) //Yes, I know round(mean_y) does the same, just left as FLOOR for consistancy sake
 	if(prob(50))
-		mean_x = Ceiling(mean_x)
+		mean_x = CEILING(mean_x, 1)
 	else
-		mean_x = Floor(mean_x)
-	var/turf/semi_random_center_turf = locate(mean_x, mean_y, ZLEVEL_STATION_PRIMARY)
+		mean_x = FLOOR(mean_x, 1)
+	var/turf/semi_random_center_turf = locate(mean_x, mean_y, z)
 	for(var/t in getline(src, semi_random_center_turf))
 		prism_turfs[t] = TRUE
 	var/placement_style = prob(50)
 	for(var/t in prism_turfs)
 		var/turf/T = t
 		if(placement_style)
-			if(IsOdd(T.x + T.y))
+			if(ISODD(T.x + T.y))
 				seven_random_hexes(T, efficiency)
 			else if(prob(50 * efficiency))
 				new /obj/effect/temp_visual/ratvar/prolonging_prism(T)
 		else
-			if(IsEven(T.x + T.y))
+			if(ISEVEN(T.x + T.y))
 				seven_random_hexes(T, efficiency)
 			else if(prob(50 * efficiency))
 				new /obj/effect/temp_visual/ratvar/prolonging_prism(T)
 		CHECK_TICK //we may be going over a hell of a lot of turfs
 
 /obj/structure/destructible/clockwork/powered/prolonging_prism/proc/get_delay_cost()
-	return Floor(delay_cost, MIN_CLOCKCULT_POWER)
+	return FLOOR(delay_cost, MIN_CLOCKCULT_POWER)
 
 /obj/structure/destructible/clockwork/powered/prolonging_prism/proc/seven_random_hexes(turf/T, efficiency)
 	var/static/list/hex_states = list("prismhex1", "prismhex2", "prismhex3", "prismhex4", "prismhex5", "prismhex6", "prismhex7")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1535,6 +1535,7 @@
 #include "code\modules\antagonists\clockcult\clock_structures\heralds_beacon.dm"
 #include "code\modules\antagonists\clockcult\clock_structures\mania_motor.dm"
 #include "code\modules\antagonists\clockcult\clock_structures\ocular_warden.dm"
+#include "code\modules\antagonists\clockcult\clock_structures\prolonging_prism.dm"
 #include "code\modules\antagonists\clockcult\clock_structures\ratvar_the_clockwork_justicar.dm"
 #include "code\modules\antagonists\clockcult\clock_structures\reflector.dm"
 #include "code\modules\antagonists\clockcult\clock_structures\stargazer.dm"


### PR DESCRIPTION
Prolonging prisms exist again. They can be built application-tier and take one minute to delay the shuttle by two minutes (So, basically, you end up with one minute more on the timer before it started). It costs 2000 power for the initial use, and 1000 additional power per time it was already used. Oh, and it creates a reeeaaally obvious effect pointing anyone towards the structure. So, good luck defending it.
Also fixes up some scripture sorting but that's minor.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
